### PR TITLE
bugfix split address for double digits in oscMappings.py

### DIFF
--- a/Instruments/Capacit/python/oscMappings.py
+++ b/Instruments/Capacit/python/oscMappings.py
@@ -201,7 +201,10 @@ def splitAddress(name):
 	for i in range(len(name)):
 		if name[i].isdigit():
 			num = int(name[i])
-			return out, num
+			if (i == len(name)-1):
+				return out, num
+			else:
+				return out, int(str(num) + name[i+1])
 		else: out = out + (name[i])
 
 def clip(input, low, hi):


### PR DESCRIPTION
fixed the issue with parsing cap10 and cap11 that was forcing sensor 1 to decrease its max value much faster than others